### PR TITLE
fix: remove wildcard CORS header

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,16 +57,8 @@ def cleanup_expired():
 
 
 # ---------------------------------------------------------------------------
-# CORS & cleanup middleware
+# Request hooks
 # ---------------------------------------------------------------------------
-
-@app.after_request
-def add_cors_headers(response):
-    response.headers["Access-Control-Allow-Origin"] = "*"
-    response.headers["Access-Control-Allow-Headers"] = "Content-Type"
-    response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
-    return response
-
 
 @app.before_request
 def before_request_hook():


### PR DESCRIPTION
## 概要

`Access-Control-Allow-Origin: *` を設定していた `add_cors_headers` ミドルウェアを削除。

SPA は同一オリジンで配信しているため CORS ヘッダーは不要。

## 変更内容

- `app.py`: `@app.after_request` の CORS ヘッダー付与処理を削除

Closes #3