### PR TITLE
feat: add rate limiting with flask-limiter (closes #4)

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,8 +3,24 @@ import uuid
 import sqlite3
 from datetime import datetime, timedelta, timezone
 from flask import Flask, request, jsonify, send_from_directory, g
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
 
 app = Flask(__name__, static_folder="static")
+
+# ---------------------------------------------------------------------------
+# Rate limiting  (closes #4)
+# ---------------------------------------------------------------------------
+limiter = Limiter(
+    get_remote_address,
+    app=app,
+    default_limits=["100/minute"],
+    storage_uri="memory://",
+    strategy="fixed-window",
+)
+# NOTE: memory:// storage is per-worker. For accurate limiting with
+# multiple gunicorn workers, switch to Redis (storage_uri="redis://...").
+# With --workers 1 the current setup is exact.
 DB_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "burnote.db")
 
 # ---------------------------------------------------------------------------
@@ -80,6 +96,7 @@ def index(path=None):
 # ---------------------------------------------------------------------------
 
 @app.route("/api/notes", methods=["POST", "OPTIONS"])
+@limiter.limit("10/minute", methods=["POST"])
 def create_note():
     if request.method == "OPTIONS":
         return "", 204
@@ -115,6 +132,7 @@ def create_note():
 
 
 @app.route("/api/notes/<note_id>", methods=["GET", "OPTIONS"])
+@limiter.limit("30/minute")
 def read_note(note_id):
     if request.method == "OPTIONS":
         return "", 204
@@ -146,6 +164,7 @@ def read_note(note_id):
 
 
 @app.route("/api/notes/<note_id>/exists", methods=["GET", "OPTIONS"])
+@limiter.limit("30/minute")
 def note_exists(note_id):
     if request.method == "OPTIONS":
         return "", 204

--- a/burnote.service
+++ b/burnote.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=exedev
 WorkingDirectory=/home/exedev/burnote
-ExecStart=/home/exedev/.local/bin/gunicorn --bind 0.0.0.0:8000 --workers 2 app:app
+ExecStart=/home/exedev/.local/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 app:app
 Restart=always
 RestartSec=3
 Environment=FLASK_ENV=production

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 flask
+flask-limiter


### PR DESCRIPTION
## 概要
全 API エンドポイントに `flask-limiter` によるレート制限を追加。

## 変更内容
- **グローバル**: 100 req/min per IP
- **POST /api/notes** (作成): 10 req/min per IP
- **GET /api/notes/<id>** (読み取り): 30 req/min per IP
- **GET /api/notes/<id>/exists**: 30 req/min per IP
- fixed-window 戦略 + インメモリストレージ
- gunicorn ワーカー数を 2→1 に変更（メモリストレージの正確性を保証）

## テスト結果
- ノート作成 11件目 → `429 Too Many Requests` ✅
- ノート存在確認 31件目 → `429 Too Many Requests` ✅

Closes #4