### PR TITLE
fix: remove /exists endpoint to prevent metadata leakage (#33)

### DIFF
--- a/app.py
+++ b/app.py
@@ -221,19 +221,6 @@ def read_note(note_id):
         db.commit()
     return jsonify(_build_response(row, new_count, False))
 
-@app.route("/api/notes/<note_id>/exists", methods=["GET", "OPTIONS"])
-@limiter.limit("30/minute")
-def note_exists(note_id):
-    if request.method == "OPTIONS":
-        return "", 204
-    db = get_db()
-    row = db.execute("SELECT id, password_hash FROM notes WHERE id = ?", (note_id,)).fetchone()
-    return jsonify({
-        "exists": row is not None,
-        "password_protected": row["password_hash"] is not None if row else False,
-    })
-
-
 
 init_db()
 

--- a/static/index.html
+++ b/static/index.html
@@ -1238,24 +1238,15 @@ async function checkAndFetchNote() {
   document.getElementById('readNotFound').style.display = 'none';
 
   try {
-    const existsRes = await fetch('/api/notes/' + currentNoteId + '/exists');
-    const existsData = await existsRes.json();
-
-    if (!existsData.exists) {
-      document.getElementById('readLoading').style.display = 'none';
-      document.getElementById('readNotFound').style.display = 'block';
-      return;
-    }
-
-    if (existsData.password_protected) {
+    await fetchNote(null);
+  } catch (e) {
+    if (e.message === 'password_required') {
       document.getElementById('readLoading').style.display = 'none';
       showPasswordModal();
     } else {
-      await fetchNote(null);
+      document.getElementById('readLoading').style.display = 'none';
+      document.getElementById('readNotFound').style.display = 'block';
     }
-  } catch (e) {
-    document.getElementById('readLoading').style.display = 'none';
-    document.getElementById('readNotFound').style.display = 'block';
   }
 }
 


### PR DESCRIPTION
## 概要

`/api/notes/<note_id>/exists` エンドポイントを廃止し、メタデータ漏洩を防止する。（closes #33）

## 問題

`/api/notes/<note_id>/exists` が認証なしで以下を返していた：
- ノートの存在有無（`exists`）
- パスワード保護状態（`password_protected`）

これにより攻撃者が：
- burn-after-read ノートの未読状態を監視可能
- パスワード保護の有無を事前に把握し攻撃戦略を立てられる
- ノートの存在確認をサイドチャネルとして利用可能

## 修正内容

Issue の修正案2を採用：**`exists` エンドポイントを廃止し、`read_note` のレスポンスのみに統一**

### バックエンド (`app.py`)
- `/api/notes/<note_id>/exists` エンドポイントを完全に削除

### フロントエンド (`static/index.html`)
- `checkAndFetchNote()` を修正：`exists` API を呼ばず直接 `/api/notes/<note_id>` を呼ぶ
- `403` (`password_required`) → パスワードモーダル表示
- `404` / その他エラー → 「メモが見つかりません」表示

## テスト確認

| シナリオ | 結果 |
|---|---|
| `/api/notes/<id>/exists` にアクセス | 404 (エンドポイント削除済み) |
| パスワードなしノートの閲覧 | 200 正常表示 |
| パスワード付きノートにパスワードなしでアクセス | 403 → パスワードモーダル表示 |
| パスワード付きノートに正しいパスワードでアクセス | 200 正常表示 |
| 存在しないノートにアクセス | 404 →「メモが見つかりません」表示 |