### PR TITLE
feat: 添付ファイルのプレビュー表示を強化

### DIFF
--- a/app.py
+++ b/app.py
@@ -185,7 +185,9 @@ def set_security_headers(response):
         "default-src 'self'; "
         "script-src 'self'; "
         "style-src 'self' 'unsafe-inline'; "
-        "img-src 'self' data:; "
+        "img-src 'self' data: blob:; "
+        "media-src blob:; "
+        "frame-src blob:; "
         "connect-src 'self'"
     )
     response.headers["X-Content-Type-Options"] = "nosniff"

--- a/static/app.js
+++ b/static/app.js
@@ -363,44 +363,50 @@ async function fetchNote(password) {
         const img = document.createElement('img');
         img.src = objUrl;
         img.alt = meta.name;
+        img.loading = 'lazy';
         previewEl.appendChild(img);
       } else if (meta.type.startsWith('video/')) {
         const video = document.createElement('video');
         video.src = objUrl;
         video.controls = true;
-        video.style.maxWidth = '100%';
+        video.playsInline = true;
+        video.preload = 'metadata';
         previewEl.appendChild(video);
       } else if (meta.type.startsWith('audio/')) {
+        const audioWrapper = document.createElement('div');
+        audioWrapper.className = 'audio-preview-wrapper';
+        const icon = document.createElement('div');
+        icon.className = 'audio-preview-icon';
+        icon.textContent = '🎵';
+        audioWrapper.appendChild(icon);
         const audio = document.createElement('audio');
         audio.src = objUrl;
         audio.controls = true;
-        audio.style.width = '100%';
-        previewEl.appendChild(audio);
+        audio.preload = 'metadata';
+        audioWrapper.appendChild(audio);
+        previewEl.appendChild(audioWrapper);
       } else if (meta.type === 'application/pdf') {
-        const embed = document.createElement('embed');
-        embed.src = objUrl;
-        embed.type = 'application/pdf';
-        embed.style.width = '100%';
-        embed.style.height = '500px';
-        embed.style.borderRadius = '8px';
-        previewEl.appendChild(embed);
+        const iframe = document.createElement('iframe');
+        iframe.src = objUrl;
+        iframe.className = 'pdf-preview-frame';
+        iframe.title = meta.name;
+        previewEl.appendChild(iframe);
       } else {
         const fallbackDiv = document.createElement('div');
-        fallbackDiv.style.padding = '1rem';
+        fallbackDiv.className = 'file-fallback-preview';
         const iconSpan = document.createElement('span');
-        iconSpan.style.fontSize = '2rem';
-        iconSpan.textContent = '📄';
+        iconSpan.className = 'file-fallback-icon';
+        iconSpan.textContent = getFileTypeIcon(meta.type, meta.name);
         fallbackDiv.appendChild(iconSpan);
-        const nameDiv = document.createElement('div');
-        nameDiv.style.cssText = 'margin-top:0.5rem; font-size:0.9rem;';
-        nameDiv.textContent = meta.name;
-        fallbackDiv.appendChild(nameDiv);
-        const infoDiv = document.createElement('div');
-        infoDiv.style.cssText = 'font-size:0.78rem; color:var(--text-dim);';
-        infoDiv.textContent = formatFileSize(meta.size) + ' ・ ' + (meta.type || '不明');
-        fallbackDiv.appendChild(infoDiv);
+        const label = document.createElement('div');
+        label.className = 'file-fallback-label';
+        label.textContent = 'プレビューできないファイル形式です';
+        fallbackDiv.appendChild(label);
         previewEl.appendChild(fallbackDiv);
       }
+
+      // Always show file info bar below preview
+      previewEl.appendChild(createFileInfoBar(meta));
 
       document.getElementById('downloadBtn').textContent = `📥 ${meta.name} をダウンロード`;
       attachmentView.style.display = 'block';
@@ -574,6 +580,40 @@ function removeAttachment(e) {
   document.getElementById('fileSizeError').style.display = 'none';
   const thumb = document.getElementById('fileThumb');
   if (thumb.src) { URL.revokeObjectURL(thumb.src); thumb.src = ''; }
+}
+
+// ---------------------------------------------------------------------------
+// Attachment preview helpers
+// ---------------------------------------------------------------------------
+function getFileTypeIcon(mimeType, fileName) {
+  if (!mimeType) return '📄';
+  if (mimeType.startsWith('image/')) return '🖼️';
+  if (mimeType.startsWith('video/')) return '🎬';
+  if (mimeType.startsWith('audio/')) return '🎵';
+  if (mimeType === 'application/pdf') return '📑';
+  if (mimeType.includes('zip') || mimeType.includes('compress') || mimeType.includes('archive')) return '🗜️';
+  if (mimeType.includes('spreadsheet') || mimeType.includes('excel') || (fileName && /\.xlsx?$/i.test(fileName))) return '📊';
+  if (mimeType.includes('presentation') || mimeType.includes('powerpoint') || (fileName && /\.pptx?$/i.test(fileName))) return '📽️';
+  if (mimeType.includes('document') || mimeType.includes('word') || mimeType.includes('text') || (fileName && /\.docx?$/i.test(fileName))) return '📝';
+  if (mimeType.includes('json') || mimeType.includes('xml') || mimeType.includes('javascript') || mimeType.includes('html')) return '💻';
+  return '📄';
+}
+
+function createFileInfoBar(meta) {
+  const bar = document.createElement('div');
+  bar.className = 'attachment-info-bar';
+  bar.innerHTML = `
+    <span class="attachment-info-icon">${getFileTypeIcon(meta.type, meta.name)}</span>
+    <span class="attachment-info-name">${escapeHtml(meta.name)}</span>
+    <span class="attachment-info-detail">${formatFileSize(meta.size)}${meta.type ? ' ・ ' + escapeHtml(meta.type) : ''}</span>
+  `;
+  return bar;
+}
+
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
 }
 
 // ---------------------------------------------------------------------------

--- a/static/index.html
+++ b/static/index.html
@@ -750,15 +750,94 @@ input[type="password"]::placeholder {
 }
 
 #attachmentPreview img,
-#attachmentPreview video,
-#attachmentPreview audio {
+#attachmentPreview video {
   max-width: 100%;
   max-height: 400px;
   border-radius: 8px;
+  display: block;
+  margin: 0 auto;
 }
 
 #attachmentPreview video {
   width: 100%;
+}
+
+#attachmentPreview audio {
+  width: 100%;
+}
+
+.audio-preview-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 0;
+}
+
+.audio-preview-wrapper .audio-preview-icon {
+  font-size: 2.5rem;
+  opacity: 0.7;
+}
+
+.audio-preview-wrapper audio {
+  width: 100%;
+  max-width: 480px;
+}
+
+.pdf-preview-frame {
+  width: 100%;
+  height: 500px;
+  border: none;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.attachment-info-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  background: var(--surface2);
+  border-radius: calc(var(--radius) - 4px);
+  font-size: 0.82rem;
+  flex-wrap: wrap;
+}
+
+.attachment-info-icon {
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.attachment-info-name {
+  font-weight: 500;
+  color: var(--text);
+  word-break: break-all;
+}
+
+.attachment-info-detail {
+  color: var(--text-dim);
+  font-size: 0.78rem;
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.file-fallback-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 2rem 1rem;
+}
+
+.file-fallback-icon {
+  font-size: 3rem;
+  opacity: 0.6;
+}
+
+.file-fallback-label {
+  font-size: 0.82rem;
+  color: var(--text-dim);
 }
 
 @media (max-width: 480px) {
@@ -822,6 +901,20 @@ input[type="password"]::placeholder {
 
   .password-modal .modal-card {
     padding: 1.5rem 1.25rem;
+  }
+
+  .pdf-preview-frame {
+    height: 350px;
+  }
+
+  .attachment-info-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+  }
+
+  .attachment-info-detail {
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
## 概要

closes #23

添付された画像・動画・音声・PDFファイルを閲覧画面で直接プレビュー表示する機能を強化。
ダウンロードしなくてもその場で確認できるUXを実現。

## 変更内容

### 🔧 CSP (Content-Security-Policy) 修正 — 根本原因の修正
- `img-src`, `media-src`, `frame-src` に `blob:` を追加
- 復号後の Blob URL がCSPによりブロックされていた問題を解消

### 🖼️ プレビュー表示の強化

| ファイルタイプ | 表示方法 | 変更点 |
|---|---|---|
| 画像 | `<img>` タグ | `loading="lazy"` 追加、中央揃え |
| 動画 | `<video>` タグ | `playsinline`, `preload="metadata"` 追加（autoplay なし） |
| 音声 | `<audio>` + 🎵アイコン | 専用ラッパーでスタイリング強化 |
| PDF | `<iframe>` タグ | `<embed>` → `<iframe>` に変更（互換性向上） |
| その他 | タイプ別アイコン | ファイルタイプに応じたアイコン + 「プレビューできないファイル形式です」 |

### 📋 共通改善
- **ファイル情報バー**: すべてのプレビューの下にアイコン・ファイル名・サイズ・MIMEタイプを常に表示
- **ファイルタイプアイコン**: MIMEタイプに応じた適切なアイコン（🖼️画像, 🎬動画, 🎵音声, 📑PDF, 📊Excel, 💻コード等）
- **escapeHtml ヘルパー追加**: XSS対策
- **モバイルレスポンシブ**: PDF iframe高さ調整、情報バーの縦レイアウト

## セキュリティ考慮
- プレビューは全てクライアントサイドで実行（サーバーに平文は送らない）
- `escapeHtml()` でファイル名のHTML injection を防止
- CSP変更は `blob:` のみ追加（最小権限の原則）

## スクリーンショット

### 画像プレビュー
復号後の画像がインラインで表示され、下部にファイル情報バーが表示される

### 音声プレビュー
🎵アイコン + オーディオプレイヤー + ファイル情報バー

### プレビュー非対応ファイル
ファイルタイプに応じたアイコン + 「プレビューできないファイル形式です」メッセージ