### PR TITLE
feat: 有効期限の拡張（7日・30日）

### DIFF
--- a/app.py
+++ b/app.py
@@ -230,7 +230,7 @@ def create_note():
             return jsonify({"error": "storage quota exceeded, please try again later"}), 507
     burn_after_read = bool(data.get("burn_after_read", False))
     expires_minutes = int(data.get("expires_minutes", 60))
-    expires_minutes = max(1, min(expires_minutes, 1440))
+    expires_minutes = max(1, min(expires_minutes, 43200))
     max_reads = int(data.get("max_reads", 0))
     max_reads = max(0, min(max_reads, 100))
     password = data.get("password")

--- a/static/index.html
+++ b/static/index.html
@@ -962,6 +962,8 @@ input[type="password"]::placeholder {
             <option value="60" selected>1時間</option>
             <option value="360">6時間</option>
             <option value="1440">24時間</option>
+            <option value="10080">7日</option>
+            <option value="43200">30日</option>
           </select>
         </div>
         <div class="option-group">


### PR DESCRIPTION
closes #16

## 変更内容
- 有効期限の選択肢に7日・30日を追加
- バックエンドのexpires_minutes上限を43200分に引き上げ