### PR TITLE
feat: ダーク/ライトモード切替

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -642,4 +642,35 @@ document.getElementById('submitPasswordBtn').addEventListener('click', submitPas
 
 setupFileAttachment();
 window.addEventListener('popstate', init);
+
+// ---------------------------------------------------------------------------
+// Theme toggle (dark/light)
+// ---------------------------------------------------------------------------
+function initTheme() {
+  const saved = localStorage.getItem('theme');
+  if (saved) {
+    document.documentElement.setAttribute('data-theme', saved);
+  } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+  updateThemeIcon();
+}
+
+function updateThemeIcon() {
+  const btn = document.getElementById('themeToggle');
+  if (!btn) return;
+  const isLight = document.documentElement.getAttribute('data-theme') === 'light';
+  btn.textContent = isLight ? '☀️' : '🌙';
+}
+
+function toggleTheme() {
+  const current = document.documentElement.getAttribute('data-theme');
+  const next = current === 'light' ? 'dark' : 'light';
+  document.documentElement.setAttribute('data-theme', next);
+  localStorage.setItem('theme', next);
+  updateThemeIcon();
+}
+
+document.getElementById('themeToggle').addEventListener('click', toggleTheme);
+initTheme();
 init();

--- a/static/index.html
+++ b/static/index.html
@@ -23,6 +23,26 @@
   --radius: 12px;
 }
 
+[data-theme="light"] {
+  --bg: #f5f5f7;
+  --surface: #ffffff;
+  --surface2: #eeeef0;
+  --border: #d1d1d6;
+  --text: #1a1a2e;
+  --text-dim: #6b6b80;
+  --accent: #7c3aed;
+  --accent2: #6d28d9;
+  --danger: #dc2626;
+  --success: #16a34a;
+}
+
+[data-theme="light"] .bg-glow {
+  background:
+    radial-gradient(ellipse 60% 40% at 50% 0%, rgba(124, 58, 237, 0.08) 0%, transparent 70%),
+    radial-gradient(ellipse 40% 50% at 80% 20%, rgba(99, 60, 200, 0.04) 0%, transparent 60%),
+    var(--bg);
+}
+
 *,
 *::before,
 *::after {
@@ -69,6 +89,29 @@ body {
 .header {
   text-align: center;
   margin-bottom: 2.5rem;
+  position: relative;
+}
+
+.theme-toggle {
+  position: absolute;
+  top: 1rem;
+  right: 0;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1.1rem;
+  transition: all 0.25s ease;
+  padding: 0;
+}
+.theme-toggle:hover {
+  border-color: var(--accent);
+  background: var(--surface);
 }
 
 .header .logo {
@@ -928,6 +971,7 @@ input[type="password"]::placeholder {
     <div class="logo">💨</div>
     <h1>煙 Kemuri</h1>
     <p class="subtitle">煙のように消える、秘密のメモ共有</p>
+    <button id="themeToggle" class="theme-toggle" aria-label="テーマ切替">🌙</button>
   </div>
 
   <!-- CREATE VIEW -->


### PR DESCRIPTION
closes #21

## 変更内容
- ライトテーマのCSS変数定義
- ヘッダーにトグルボタン追加（🌙/☀️）
- prefers-color-schemeでOS設定を自動検出
- localStorageで選択を保存