### PR TITLE
feat: スクリーンショット抑止機能

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,6 +111,8 @@ def init_db():
         conn.execute("ALTER TABLE notes ADD COLUMN is_markdown INTEGER NOT NULL DEFAULT 0")
     if "webhook_url" not in columns:
         conn.execute("ALTER TABLE notes ADD COLUMN webhook_url TEXT")
+    if "no_copy" not in columns:
+        conn.execute("ALTER TABLE notes ADD COLUMN no_copy INTEGER NOT NULL DEFAULT 0")
     # Migrate: move BLOB/TEXT attachment_data from DB to filesystem
     if "attachment_data" in columns:
         rows = conn.execute("SELECT id, attachment_data FROM notes WHERE attachment_data IS NOT NULL").fetchall()
@@ -244,6 +246,7 @@ def create_note():
     is_markdown = bool(data.get("is_markdown", False))
     password = data.get("password")
     pw_hash = generate_password_hash(password) if password else None
+    no_copy = bool(data.get("no_copy", False))
     webhook_url = data.get("webhook_url")
     if webhook_url:
         webhook_url = str(webhook_url).strip()
@@ -258,9 +261,9 @@ def create_note():
         save_attachment(note_id, attachment_blob)
         has_attachment = 1
     db.execute(
-        "INSERT INTO notes (id, content, burn_after_read, created_at, expires_at, read_count, max_reads, password_hash, has_attachment, attachment_meta, is_markdown, webhook_url) "
-        "VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)",
-        (note_id, content or '', int(burn_after_read), now.isoformat(), expires_at.isoformat(), max_reads, pw_hash, has_attachment, attachment_meta, int(is_markdown), webhook_url or None),
+        "INSERT INTO notes (id, content, burn_after_read, created_at, expires_at, read_count, max_reads, password_hash, has_attachment, attachment_meta, is_markdown, webhook_url, no_copy) "
+        "VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)",
+        (note_id, content or '', int(burn_after_read), now.isoformat(), expires_at.isoformat(), max_reads, pw_hash, has_attachment, attachment_meta, int(is_markdown), webhook_url or None, int(no_copy)),
     )
     db.commit()
     base_url = request.host_url.rstrip("/")
@@ -295,7 +298,7 @@ def read_note(note_id):
     db = get_db()
     now = datetime.now(timezone.utc).isoformat()
 
-    _NOTE_COLS = "id, content, burn_after_read, created_at, expires_at, read_count, max_reads, password_hash, has_attachment, attachment_meta, is_markdown, webhook_url"
+    _NOTE_COLS = "id, content, burn_after_read, created_at, expires_at, read_count, max_reads, password_hash, has_attachment, attachment_meta, is_markdown, webhook_url, no_copy"
     row = db.execute(f"SELECT {_NOTE_COLS} FROM notes WHERE id = ?", (note_id,)).fetchone()
     if row is None:
         return jsonify({"error": "Note not found or has expired"}), 404
@@ -320,6 +323,7 @@ def read_note(note_id):
             "read_count": read_count,
             "max_reads": row["max_reads"],
             "password_protected": is_password_protected,
+            "no_copy": bool(row["no_copy"]),
         }
         if row["has_attachment"]:
             attachment_bytes = load_attachment(row["id"])

--- a/static/app.js
+++ b/static/app.js
@@ -157,6 +157,7 @@ async function createNote() {
       max_reads: burnToggle ? 0 : maxReads,
       password: password,
       webhook_url: document.getElementById('webhookUrl').value.trim() || undefined,
+      no_copy: document.getElementById('noCopyToggle').checked,
       is_markdown: document.getElementById('markdownToggle').checked,
     };
     if (encAttachmentData) {
@@ -465,6 +466,24 @@ async function fetchNote(password) {
   if (data.max_reads > 0) metaHtml += `<span>📊 ${data.read_count}/${data.max_reads}回</span>`;
   if (data.password_protected) metaHtml += `<span>🔑 パスワード保護</span>`;
   document.getElementById('noteMeta').innerHTML = metaHtml;
+
+  // No-copy protection
+  if (data.no_copy) {
+    noteTextEl.classList.add('no-copy-protected', 'no-copy-watermark');
+    noteTextEl.setAttribute('data-watermark', new Date().toLocaleString('ja-JP'));
+    const notice = document.createElement('div');
+    notice.className = 'no-copy-notice';
+    notice.textContent = '🛡️ このメモはコピー抑止が有効です（完全な防止ではありません）';
+    noteTextEl.parentNode.insertBefore(notice, noteTextEl);
+    noteTextEl.addEventListener('contextmenu', e => e.preventDefault());
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        noteTextEl.classList.add('content-blurred');
+      } else {
+        noteTextEl.classList.remove('content-blurred');
+      }
+    });
+  }
 
   // Remove key from URL
   if (window.location.hash) {

--- a/static/index.html
+++ b/static/index.html
@@ -581,6 +581,42 @@ input[type="password"]::placeholder {
   transition: opacity 1s ease;
 }
 
+.no-copy-protected {
+  user-select: none;
+  -webkit-user-select: none;
+}
+.no-copy-watermark {
+  position: relative;
+}
+.no-copy-watermark::after {
+  content: attr(data-watermark);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-30deg);
+  font-size: 1.5rem;
+  color: rgba(139, 92, 246, 0.07);
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 1;
+}
+.no-copy-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: rgba(139, 92, 246, 0.08);
+  border: 1px solid rgba(139, 92, 246, 0.2);
+  border-radius: calc(var(--radius) - 4px);
+  font-size: 0.8rem;
+  color: var(--accent2);
+  margin-bottom: 0.75rem;
+}
+.content-blurred {
+  filter: blur(8px);
+  transition: filter 0.3s ease;
+}
+
 .note-content.dissolving {
   animation: smokeDissolve 3s ease forwards;
   pointer-events: none;
@@ -1144,6 +1180,14 @@ input[type="password"]::placeholder {
         <div class="option-group">
           <label for="notePassword">🔑 パスワード（任意）</label>
           <input type="password" id="notePassword" placeholder="未設定">
+        </div>
+        <div class="option-group">
+          <label>🛡️ コピー抑止</label>
+          <label class="toggle">
+            <input type="checkbox" id="noCopyToggle">
+            <span class="toggle-slider"></span>
+            スクショ・コピー抑止
+          </label>
         </div>
         <div class="option-group">
           <label>📝 Markdown</label>


### PR DESCRIPTION
closes #24

## 変更内容
- 作成時にコピー抑止トグル追加
- テキスト選択無効化 (user-select: none)
- 透かし（閲覧日時）オーバーレイ
- 右クリック無効化
- タブ切替時のぼかし表示
- 完全な防止ではない旨の注意表示