### PR TITLE
コピー抑止をデフォルト有効に変更

### DIFF
--- a/app.py
+++ b/app.py
@@ -113,7 +113,7 @@ def init_db():
     if "webhook_url" not in columns:
         conn.execute("ALTER TABLE notes ADD COLUMN webhook_url TEXT")
     if "no_copy" not in columns:
-        conn.execute("ALTER TABLE notes ADD COLUMN no_copy INTEGER NOT NULL DEFAULT 0")
+        conn.execute("ALTER TABLE notes ADD COLUMN no_copy INTEGER NOT NULL DEFAULT 1")
     if "allowed_ips" not in columns:
         conn.execute("ALTER TABLE notes ADD COLUMN allowed_ips TEXT")
     # Migrate: move BLOB/TEXT attachment_data from DB to filesystem
@@ -249,7 +249,7 @@ def create_note():
     is_markdown = bool(data.get("is_markdown", False))
     password = data.get("password")
     pw_hash = generate_password_hash(password) if password else None
-    no_copy = bool(data.get("no_copy", False))
+    no_copy = bool(data.get("no_copy", True))
     allowed_ips = data.get("allowed_ips")
     if allowed_ips:
         allowed_ips = str(allowed_ips).strip()

--- a/static/app.js
+++ b/static/app.js
@@ -157,7 +157,7 @@ async function createNote() {
       max_reads: burnToggle ? 0 : maxReads,
       password: password,
       webhook_url: document.getElementById('webhookUrl').value.trim() || undefined,
-      no_copy: document.getElementById('noCopyToggle').checked,
+      no_copy: true,
       allowed_ips: document.getElementById('allowedIps').value.trim() || undefined,
       is_markdown: document.getElementById('markdownToggle').checked,
     };

--- a/static/index.html
+++ b/static/index.html
@@ -1381,14 +1381,6 @@ input[type="password"]::placeholder {
           <input type="password" id="notePassword" placeholder="未設定">
         </div>
         <div class="option-group">
-          <label>🛡️ コピー抑止</label>
-          <label class="toggle">
-            <input type="checkbox" id="noCopyToggle">
-            <span class="toggle-slider"></span>
-            スクショ・コピー抑止
-          </label>
-        </div>
-        <div class="option-group">
           <label>📝 Markdown</label>
           <label class="toggle">
             <input type="checkbox" id="markdownToggle">


### PR DESCRIPTION
## 概要

コピー抑止をオプション（トグル）ではなく、すべてのノートでデフォルト有効にする。

## 変更内容

- 作成画面の「🛡️ コピー抑止」トグルUIを削除
- JS側で常に `no_copy: true` を固定送信
- サーバー側のデフォルト値を `True` に変更（API直接利用時も有効）
- DBカラムのデフォルトを `1` に変更

## 影響

すべての新規ノートに以下が自動適用されます:
- `user-select: none`（テキスト選択抑止）
- 右クリック無効
- タブ切替時のコンテンツぼかし
- ウォーターマーク表示

> ⚠️ 既存の `no_copy=0` のノートには影響しません。